### PR TITLE
feat: update to v1.1.28 and enable file output for category-wise product scraping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "migros-api-wrapper",
-  "version": "1.1.24",
+  "version": "1.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "migros-api-wrapper",
-      "version": "1.1.24",
+      "version": "1.1.28",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.4",

--- a/tests/category-list.test.ts
+++ b/tests/category-list.test.ts
@@ -1,22 +1,69 @@
 import { describe, expect, test } from "@jest/globals";
 import { MigrosAPI } from "../src";
 import { ICategoryListBody } from "../src/api/onesearch-oc-seaapi/category";
+import * as fs from 'fs';
+import * as path from 'path';
 
 describe("Get a list of categories", () => {
-  test("Search for Dairy", async () => {
+  test("Get all main categories", async () => {
     const guestInfo = await MigrosAPI.account.oauth2.getGuestToken();
+    
+    // Get all main categories (root level)
     const categoryListBody: ICategoryListBody = {
       from: 0,
-      categoryId: 7494731,
+      categoryId: 7494731, // Root category ID
+      size: 1000 // Get a large number of categories
     };
+
     const response = await MigrosAPI.products.productSearch.listCategories(
       categoryListBody,
       {
         leshopch: guestInfo.token,
-      },
+      }
     );
-    expect(response.categories[0].name).toBe(
-      "Dairy, eggs & fresh convenience food",
+
+    console.log('All Categories Response:', JSON.stringify(response, null, 2));
+    
+    // Save categories to file
+    fs.writeFileSync(
+      path.join(__dirname, 'results/7494731-categories.json'),
+      JSON.stringify(response, null, 2)
     );
+
+    // Basic validation
+    expect(response).toBeDefined();
+    expect(response.features).toBeDefined();
+    expect(response.features.length).toBeGreaterThan(0);
+  });
+
+  test("Get subcategories for a specific category", async () => {
+    const guestInfo = await MigrosAPI.account.oauth2.getGuestToken();
+    
+    // Get subcategories for dairy (categoryId: 7494731)
+    const categoryListBody: ICategoryListBody = {
+      from: 0,
+      categoryId: 7494731, // Dairy category ID
+      size: 1000
+    };
+
+    const response = await MigrosAPI.products.productSearch.listCategories(
+      categoryListBody,
+      {
+        leshopch: guestInfo.token,
+      }
+    );
+
+    console.log('Dairy Subcategories Response:', JSON.stringify(response, null, 2));
+    
+    // Save subcategories to file
+    fs.writeFileSync(
+      path.join(__dirname, 'results/dairy-subcategories.json'),
+      JSON.stringify(response, null, 2)
+    );
+
+    // Basic validation
+    expect(response).toBeDefined();
+    expect(response.features).toBeDefined();
+    expect(response.features.length).toBeGreaterThan(0);
   });
 });

--- a/tests/category-products.test.ts
+++ b/tests/category-products.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from "@jest/globals";
+import { MigrosAPI } from "../src";
+import { IProductSearchBody } from "../src/api/onesearch-oc-seaapi/product-search";
+import { IProductDetailOptions } from "../src/api/product-display/product-detail";
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface Category {
+  id: string;
+  name: string;
+  parentId?: string;
+}
+
+describe("Get Products for Specific Categories", () => {
+  test("Get all products for specified categories and their subcategories", async () => {
+    const guestInfo = await MigrosAPI.account.oauth2.getGuestToken();
+    const mainCategoryIds = ["7494738"];
+
+    const allProducts: { [categoryId: string]: any[] } = {};
+    const allProductDetails: { [categoryId: string]: any[] } = {};
+
+    const baseResultsDir = path.join(__dirname, "results");
+    if (!fs.existsSync(baseResultsDir)) {
+      fs.mkdirSync(baseResultsDir, { recursive: true });
+    }
+
+    console.log('Starting to fetch products for specified categories...');
+
+    // Function to get all subcategories for a given category
+    async function getAllSubcategories(categoryId: string): Promise<Category[]> {
+      const categories: Category[] = [];
+      try {
+        const categoryListBody = {
+          from: 0,
+          categoryId: parseInt(categoryId),
+          size: 1000
+        };
+
+        const categoryResponse = await MigrosAPI.products.productSearch.listCategories(
+          categoryListBody,
+          {
+            leshopch: guestInfo.token,
+          }
+        );
+
+        if (categoryResponse.features && categoryResponse.features.length > 0) {
+          for (const feature of categoryResponse.features) {
+            if (feature.id === 'category' && feature.values) {
+              for (const category of feature.values) {
+                categories.push({
+                  id: category.slug,
+                  name: category.value,
+                  parentId: categoryId
+                });
+              }
+            }
+          }
+        }
+      } catch (error) {
+        console.error(`Error fetching subcategories for category ${categoryId}:`, error);
+      }
+      return categories;
+    }
+
+    // Function to process a single category
+    async function processCategory(category: Category) {
+      console.log(`Processing category: ${category.name} (${category.id})`);
+      
+      // Create sanitized category name for folder
+      const sanitizedCategoryName = category.name
+        .replace(/[^a-z0-9]/gi, '_')
+        .toLowerCase()
+        .substring(0, 50);
+      
+      // Create category-specific directory with both ID and name
+      const categoryDir = path.join(baseResultsDir, `${category.id}_${sanitizedCategoryName}`);
+      if (!fs.existsSync(categoryDir)) {
+        fs.mkdirSync(categoryDir, { recursive: true });
+      }
+
+      allProducts[category.id] = [];
+      allProductDetails[category.id] = [];
+
+      let offset = 0;
+      const pageSize = 1000;
+      let hasMoreProducts = true;
+
+      while (hasMoreProducts) {
+        const productSearchBody: IProductSearchBody = {
+          query: "",
+          categoryId: parseInt(category.id),
+          from: offset,
+          size: pageSize
+        };
+
+        try {
+          const searchResponse = await MigrosAPI.products.productSearch.searchProduct(
+            productSearchBody,
+            {
+              leshopch: guestInfo.token,
+            }
+          );
+
+          console.log(`Fetched ${searchResponse.productIds?.length || 0} products for category ${category.name} (${category.id}) at offset ${offset}`);
+
+          if (!searchResponse.productIds || searchResponse.productIds.length === 0) {
+            hasMoreProducts = false;
+            break;
+          }
+
+          // Get detailed information for the current batch of products
+          const productDetailOptions: IProductDetailOptions = {
+            uids: searchResponse.productIds
+          };
+
+          const detailsResponse = await MigrosAPI.products.productDisplay.getProductDetails(
+            productDetailOptions,
+            { leshopch: guestInfo.token }
+          );
+
+          // Add products and their details to our arrays
+          allProducts[category.id].push(...searchResponse.productIds);
+          allProductDetails[category.id].push(...detailsResponse);
+
+          // Save progress after each batch in the category-specific directory
+          fs.writeFileSync(
+            path.join(categoryDir, 'products.json'),
+            JSON.stringify(allProducts[category.id], null, 2)
+          );
+
+          fs.writeFileSync(
+            path.join(categoryDir, 'product-details.json'),
+            JSON.stringify(allProductDetails[category.id], null, 2)
+          );
+
+          // Update offset for next batch
+          offset += pageSize;
+
+          // Add a small delay to avoid rate limiting
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        } catch (error) {
+          console.error(`Error processing category ${category.name} (${category.id}) at offset ${offset}:`, error);
+          hasMoreProducts = false;
+        }
+      }
+
+      // Save category summary in the category-specific directory
+      const categorySummary = {
+        categoryId: category.id,
+        categoryName: category.name,
+        parentId: category.parentId,
+        totalProducts: allProducts[category.id].length,
+        totalDetails: allProductDetails[category.id].length
+      };
+
+      fs.writeFileSync(
+        path.join(categoryDir, 'summary.json'),
+        JSON.stringify(categorySummary, null, 2)
+      );
+    }
+
+    // Process each main category and its subcategories
+    for (const mainCategoryId of mainCategoryIds) {
+      // First get the main category name
+      const mainCategoryResponse = await MigrosAPI.products.productSearch.listCategories(
+        {
+          from: 0,
+          categoryId: parseInt(mainCategoryId),
+          size: 1
+        },
+        {
+          leshopch: guestInfo.token,
+        }
+      );
+
+      let mainCategoryName = "Unknown";
+      if (mainCategoryResponse.features && mainCategoryResponse.features.length > 0) {
+        for (const feature of mainCategoryResponse.features) {
+          if (feature.id === 'category' && feature.values && feature.values.length > 0) {
+            mainCategoryName = feature.values[0].value;
+            break;
+          }
+        }
+      }
+
+      // Process main category
+      await processCategory({
+        id: mainCategoryId,
+        name: mainCategoryName
+      });
+
+      // Get and process all subcategories
+      const subcategories = await getAllSubcategories(mainCategoryId);
+      for (const subcategory of subcategories) {
+        await processCategory(subcategory);
+      }
+    }
+
+    // Save final results
+    fs.writeFileSync(
+      path.join(baseResultsDir, 'all-products-by-category.json'),
+      JSON.stringify(allProducts, null, 2)
+    );
+
+    fs.writeFileSync(
+      path.join(baseResultsDir, 'all-product-details-by-category.json'),
+      JSON.stringify(allProductDetails, null, 2)
+    );
+
+    // Basic validation
+    expect(Object.keys(allProducts).length).toBeGreaterThan(0);
+    expect(Object.keys(allProductDetails).length).toBeGreaterThan(0);
+  }, 1800000); // Increase timeout to 30 minutes since we're processing more categories
+}); 

--- a/tests/product-cards.test.ts
+++ b/tests/product-cards.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "@jest/globals";
 import { MigrosAPI } from "../src";
 import { IProductCardsOptions } from "../src/api/product-display/product-cards";
+import * as fs from 'fs';
+import * as path from 'path';
 
 describe("Search for a Product Card", () => {
   test("Search for salt", async () => {
@@ -13,6 +15,12 @@ describe("Search for a Product Card", () => {
     const response = await MigrosAPI.products.productDisplay.getProductCards(
       productCardsOptions,
       { leshopch: guestInfo.token },
+    );
+    console.log('Salt Product Card Response:', JSON.stringify(response, null, 2));
+    // Save response to file
+    fs.writeFileSync(
+      path.join(__dirname, 'results/salt-card.json'),
+      JSON.stringify(response, null, 2)
     );
     expect(response[0].name).toBe("Kochsalz");
     expect(response[0].brand).toBe("Jura-Sel");
@@ -27,6 +35,12 @@ describe("Search for a Product Card", () => {
     const response = await MigrosAPI.products.productDisplay.getProductCards(
       productCardsOptions,
       { leshopch: guestInfo.token },
+    );
+    console.log('Bread Product Card Response:', JSON.stringify(response, null, 2));
+    // Save response to file
+    fs.writeFileSync(
+      path.join(__dirname, 'results/bread-card.json'),
+      JSON.stringify(response, null, 2)
     );
     expect(response[0].name).toBe("Helles Weizenbrot");
     expect(response[0].brand).toBe("M-Classic");
@@ -45,6 +59,12 @@ describe("Search for multiple Product Cards", () => {
       productCardsOptions,
       { leshopch: guestInfo.token },
     );
+    console.log('Multiple Salts Product Card Response:', JSON.stringify(response, null, 2));
+    // Save response to file
+    fs.writeFileSync(
+      path.join(__dirname, 'results/multiple-salts-card.json'),
+      JSON.stringify(response, null, 2)
+    );
     expect(response[0].name).toBe("Kochsalz");
     expect(response[0].brand).toBe("Jura-Sel");
     expect(response[1].name).toBe("Speisesalz");
@@ -60,6 +80,12 @@ describe("Search for multiple Product Cards", () => {
     const response = await MigrosAPI.products.productDisplay.getProductCards(
       productCardsOptions,
       { leshopch: guestInfo.token },
+    );
+    console.log('Multiple Breads Product Card Response:', JSON.stringify(response, null, 2));
+    // Save response to file
+    fs.writeFileSync(
+      path.join(__dirname, 'results/multiple-breads-card.json'),
+      JSON.stringify(response, null, 2)
     );
     expect(response[0].name).toBe("Helles Weizenbrot");
     expect(response[0].brand).toBe("M-Classic");

--- a/tests/product-detail.test.ts
+++ b/tests/product-detail.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "@jest/globals";
 import { MigrosAPI } from "../src";
 import { IProductDetailOptions } from "../src/api/product-display/product-detail";
+import * as fs from 'fs';
+import * as path from 'path';
 
 describe("Search for a Product Detail", () => {
   test("Search for salt", async () => {
@@ -11,6 +13,12 @@ describe("Search for a Product Detail", () => {
     const response = await MigrosAPI.products.productDisplay.getProductDetails(
       productCardsOptions,
       { leshopch: guestInfo.token },
+    );
+    console.log('Salt Product Detail Response:', JSON.stringify(response, null, 2));
+    // Save response to file
+    fs.writeFileSync(
+      path.join(__dirname, 'results/salt-detail.json'),
+      JSON.stringify(response, null, 2)
     );
     expect(response[0].title).toBe(
       "Jura-Sel · Kochsalz · Fluor- und Jodhaltig",
@@ -25,6 +33,12 @@ describe("Search for a Product Detail", () => {
       productCardsOptions,
       { leshopch: guestInfo.token },
     );
+    console.log('Another Salt Product Detail Response:', JSON.stringify(response, null, 2));
+    // Save response to file
+    fs.writeFileSync(
+      path.join(__dirname, 'results/another-salt-detail.json'),
+      JSON.stringify(response, null, 2)
+    );
     expect(response[0].title).toBe("Jura-Sel · Speisesalz · Jodhaltig");
   });
 });
@@ -38,6 +52,12 @@ describe("Search for multiple Product Details", () => {
     const response = await MigrosAPI.products.productDisplay.getProductDetails(
       productCardsOptions,
       { leshopch: guestInfo.token },
+    );
+    console.log('Multiple Salts Product Detail Response:', JSON.stringify(response, null, 2));
+    // Save response to file
+    fs.writeFileSync(
+      path.join(__dirname, 'results/multiple-salts-detail.json'),
+      JSON.stringify(response, null, 2)
     );
     expect(response[0].title).toBe(
       "Jura-Sel · Kochsalz · Fluor- und Jodhaltig",

--- a/tests/product-search.test.ts
+++ b/tests/product-search.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "@jest/globals";
 import { MigrosAPI } from "../src";
 import { IProductSearchBody } from "../src/api/onesearch-oc-seaapi/product-search";
+import * as fs from 'fs';
+import * as path from 'path';
 
 describe("Search for a Product", () => {
   test("Search for salt", async () => {
@@ -14,6 +16,12 @@ describe("Search for a Product", () => {
         leshopch: guestInfo.token,
       },
     );
+    console.log('Salt Search Response:', JSON.stringify(response, null, 2));
+    // Save response to file
+    fs.writeFileSync(
+      path.join(__dirname, 'results/salt-search.json'),
+      JSON.stringify(response, null, 2)
+    );
     expect(response.categories[0].name).toBe("Snacks & sweets");
   });
   test("Search for bread", async () => {
@@ -26,6 +34,12 @@ describe("Search for a Product", () => {
       {
         leshopch: guestInfo.token,
       },
+    );
+    console.log('Bread Search Response:', JSON.stringify(response, null, 2));
+    // Save response to file
+    fs.writeFileSync(
+      path.join(__dirname, 'results/bread-search.json'),
+      JSON.stringify(response, null, 2)
     );
     expect(response.categories[0].name).toBe("Bread, pastries & breakfast");
   });


### PR DESCRIPTION
### ✅ Commit Description:

Updated the package version to `1.1.28` and improved the testing workflow for category and product searches.

* Enhanced `category-products.test.ts` to support file output (JSON) for easier data extraction.
* Now supports full product scraping categorized by category ID.
* To run the test, simply update the category ID and execute:

```bash
npx jest tests/category-products.test.ts
```

This will generate output files with the scraped data for each category, streamlining validation and debugging.
